### PR TITLE
vimrcにおける新規機能を追加

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,4 @@
-if has('vim_starting')
+as('vim_starting')
    " 初回起動時のみruntimepathにneobundleのパスを指定する
    set runtimepath+=~/.vim/bundle/neobundle.vim/
 endif
@@ -23,8 +23,6 @@ syntax on
 " 行番号の色を設定
 hi LineNr ctermbg=0 ctermfg=0
 hi CursorLineNr ctermbg=4 ctermfg=0
-set cursorline
-hi clear CursorLinou
 
 " ファイルタイプ別のプラグイン/インデントを有効にする
 filetype plugin indent on
@@ -138,4 +136,3 @@ inoremap <Right> <Nop>
 
 " helpを日本語化
 set helplang=ja,en
-

--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,6 @@
-as('vim_starting')
+colorscheme default
+
+if has('vim_starting')
    " 初回起動時のみruntimepathにneobundleのパスを指定する
    set runtimepath+=~/.vim/bundle/neobundle.vim/
 endif


### PR DESCRIPTION
# vimでインデントを見やすくする方法

## まずはNeoBundleをcloneしてくる
```
~/.vim/bundle
git clone git://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
```

## 次に~/.vimrcに以下を記述
```
colorscheme default

"#NeoBundle設定
if has('vim_starting')
   "# 初回起動時のみruntimepathにneobundleのパスを指定する
   set runtimepath+=~/.vim/bundle/neobundle.vim/
endif

"# NeoBundleを初期化
call neobundle#begin(expand('~/.vim/bundle/'))

"# インデントに色を付けて見やすくする
NeoBundle 'nathanaelkane/vim-indent-guides'

"#vim立ち上げたときに、自動的にvim-indent-guidesをオンにする
let g:indent_guides_enable_on_vim_startup=1

"# ガイドの幅
let g:indent_guides_guide_size = 1

call neobundle#end()

"# ファイルタイプ別のプラグイン/インデントを有効にする
filetype plugin indent on
```

## vimのコマンドモードにて以下を実行
`:NeoBundleInstall`